### PR TITLE
I had a problem with Vault, Commit adds simple fix

### DIFF
--- a/src/de/bananaco/bpermissions/api/ApiLayer.java
+++ b/src/de/bananaco/bpermissions/api/ApiLayer.java
@@ -197,6 +197,9 @@ public class ApiLayer {
 			return "";
 		Calculable c = w.get(name, type);
 		String v = c.getEffectiveValue(key);
+                if (v == null) {
+                    return "";
+                }
 		// Add support for prefix/suffix from global files
 		if(v.equals("") && wm.getUseGlobalFiles()) {
 			w = wm.getDefaultWorld();


### PR DESCRIPTION
When I was attempting to request the prefix for a player via Vault, a NPE was thrown due to the Meta field being empty of the Prefix key. I didn't look into it much, so I probably did something stupid instead.
